### PR TITLE
Fix issue to avoid roots with zero degree

### DIFF
--- a/graph500.c
+++ b/graph500.c
@@ -155,14 +155,16 @@ run_bfs (void)
     /* Sample from {0, ..., nvtx_scale-1} without replacement, but
        only from vertices with degree > 0. */
     m = 0;
-    t = 0;
-    for (k = 0; k < nvtx_scale && m < NBFS && t < nvtx_connected; ++k) {
-      if (has_adj[k]) {
-	double R = mrg_get_double_orig (prng_state);
-	if ((nvtx_connected - t)*R > NBFS - m) ++t;
-	else bfs_root[m++] = t++;
+    for (k = 0; k < nvtx_scale && m < NBFS; ++k) {
+      unsigned long challenge = (unsigned long)(mrg_get_double_orig(prng_state) * (double)(nvtx_scale-1));
+
+      if (has_adj[challenge]) {
+        size_t i=0;
+        for (; i<m; i++) if (bfs_root[i] == challenge) break; // check for duplicates
+        if (i == m) bfs_root[m++] = challenge; // if not duplicate, add to list
       }
     }
+	  
     if (t >= nvtx_connected && m < NBFS) {
       if (m > 0) {
 	fprintf (stderr, "Cannot find %d sample roots of non-self degree > 0, using %d.\n",


### PR DESCRIPTION
The old root generated generated 50% roots with degree zero, leading to very wrong results. This commit resolves that.

By having 50% roots with degree zero, the old results were about twice as high as they should be. 

This closes #2