### PR TITLE
Fixed make-edgelist and input graph reading bugs.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ GRAPH500_SOURCES=graph500.c options.c rmat.c kronecker.c verify.c prng.c \
 MAKE_EDGELIST_SOURCES=make-edgelist.c options.c rmat.c kronecker.c prng.c \
 	xalloc.c timer.c 
 
-BIN=seq-list/seq-list seq-csr/seq-csr make-edgelist
+BIN=seq-list/seq-list seq-csr/seq-csr make-edgelist graph5002el
 
 ifeq ($(BUILD_OPENMP), Yes)
 BIN += omp-csr/omp-csr
@@ -37,6 +37,7 @@ CPPFLAGS += -I./generator
 make-edgelist: CFLAGS:=$(CFLAGS) $(CFLAGS_OPENMP)
 make-edgelist:	make-edgelist.c options.c rmat.c kronecker.c prng.c \
 	xalloc.c timer.c $(addprefix generator/,$(GENERATOR_SRCS))
+graph5002el: graph5002el.c xalloc.c $(addprefix generator/,$(GENERATOR_SRCS))
 
 seq-list/seq-list: seq-list/seq-list.c $(GRAPH500_SOURCES) \
 	$(addprefix generator/,$(GENERATOR_SRCS))

--- a/graph500.c
+++ b/graph500.c
@@ -346,6 +346,11 @@ output_results (const int64_t SCALE, int64_t nvtx_scale, int64_t edgefactor,
   printf ("construction_time: %20.17e\n", construction_time);
   printf ("nbfs: %d\n", NBFS);
 
+  // Print out each time so the user can make her own statistics.
+  for (k = 0; k < NBFS; k++) {
+    printf ("bfs_time[%d]: %20.17e\n", k, bfs_time[k]);
+  }
+
   memcpy (tm, bfs_time, NBFS*sizeof(tm[0]));
   statistics (stats, tm, NBFS);
   PRINT_STATS("time", 0);

--- a/graph500.c
+++ b/graph500.c
@@ -79,10 +79,10 @@ main (int argc, char **argv)
     the following if () {} else {} with a statement pointing IJ
     to wherever the edge list is mapped into the simulator's memory.
   */
+  nedge = desired_nedge;
   if (!dumpname) {
     if (VERBOSE) fprintf (stderr, "Generating edge list...");
     if (use_RMAT) {
-      nedge = desired_nedge;
       IJ = xmalloc_large_ext (nedge * sizeof (*IJ));
       TIME(generation_time, rmat_edgelist (IJ, nedge, SCALE, A, B, C));
     } else {
@@ -96,7 +96,8 @@ main (int argc, char **argv)
       perror ("Cannot open input graph file");
       return EXIT_FAILURE;
     }
-    sz = nedge * sizeof (*IJ);
+    sz = nedge * sizeof (*IJ) / 2;
+    IJ = xmalloc_large_ext (nedge * sizeof (*IJ));
     if (sz != read (fd, IJ, sz)) {
       perror ("Error reading input graph file");
       return EXIT_FAILURE;

--- a/graph5002el.c
+++ b/graph5002el.c
@@ -1,0 +1,71 @@
+/*  Converts from the binary format used in the graph500 to the simpler
+ *  edge list format of one <vertex1> <vertex2> pair per line in ASCII
+ *  Assumes you can fit the entire graph in memory (the same assumption
+ *  the graph500 makes)
+ *  Author: Samuel Pollard
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include "xalloc.h" // for xmaloc_large_ext
+#include "generator/make_graph.h" // for packed_edge
+#include "options.h" // for NBFS_max
+
+static const char* usage =
+    "usage: graph5002el <inputedges> <inputroots> <outputedges> <outputroots>";
+static struct packed_edge * restrict IJ;
+
+int main (int argc, char **argv)
+{
+  if (argc != 5) {
+    printf ("%s\n", usage);
+    return EXIT_FAILURE;
+  }
+
+  /* Convert the roots */
+  ssize_t sz, sz_read;
+  FILE* infp = fopen (argv[2], "r");
+  fseek (infp, 0L, SEEK_END);
+  sz = ftell (infp);
+  rewind (infp);
+  printf ("Found %ld roots\n", sz / 8); // VERBOSE
+  int64_t bfs_root[sz / 8]; // ~64, small enough for the stack
+  if ((sz_read = fread (bfs_root, 1, sz, infp)) != sz) {
+    fprintf (stderr, "Expected %ld bytes, read %ld\n", sz, sz_read);
+    return EXIT_FAILURE;
+  }
+  fclose (infp);
+  FILE* outfp = fopen (argv[4], "w");
+  int64_t m;
+  for (m = 0; m < sz / 8; m++) {
+    fprintf (outfp, "%lld\n", bfs_root[m]);
+  }
+  fclose (outfp);
+
+  /* Convert the edge list */ 
+  infp = fopen (argv[1], "r");
+  fseek (infp, 0L, SEEK_END);
+  sz = ftell (infp);
+  rewind (infp);
+  /* This is a highly suboptimal way of doing things.
+   * If the graph can't fit in RAM, this could be modifed to loop
+   * making sure to read in multiples of  sizeof(struct packed_edge)
+   */
+  const size_t chunks = 1;
+  IJ = xmalloc_large_ext (sz / chunks);
+  printf ("Found %ld edges\n", sz / sizeof(*IJ)); // VERBOSE
+  if ((sz_read = fread (IJ, 1, sz, infp)) != sz) {
+    fprintf (stderr, "Expected %ld bytes, read %ld\n", sz, sz_read);
+    return EXIT_FAILURE;
+  }
+  fclose (infp);
+  outfp = fopen (argv[3], "w");
+  int64_t i,j;
+  for (m = 0; m < sz / sizeof(*IJ); m++) {
+    i = get_v0_from_edge(&IJ[m]);
+    j = get_v1_from_edge(&IJ[m]);
+    fprintf (outfp, "%lld %lld\n", i, j);
+  }
+  xfree_large (IJ);
+
+  return EXIT_SUCCESS;
+}

--- a/graph5002el.c
+++ b/graph5002el.c
@@ -23,7 +23,11 @@ int main (int argc, char **argv)
 
   /* Convert the roots */
   ssize_t sz, sz_read;
-  FILE* infp = fopen (argv[2], "r");
+  FILE* infp;
+  if ((infp  = fopen (argv[2], "r")) == NULL) {
+    perror("Can't read file at argv[2]");
+    return EXIT_FAILURE;
+  }
   fseek (infp, 0L, SEEK_END);
   sz = ftell (infp);
   rewind (infp);
@@ -34,7 +38,11 @@ int main (int argc, char **argv)
     return EXIT_FAILURE;
   }
   fclose (infp);
-  FILE* outfp = fopen (argv[4], "w");
+  FILE* outfp;
+  if ((outfp = fopen (argv[4], "w")) == NULL) {
+    perror("Can't write file at argv[4]");
+    return EXIT_FAILURE;
+  }
   int64_t m;
   for (m = 0; m < sz / 8; m++) {
     fprintf (outfp, "%lld\n", bfs_root[m]);
@@ -42,13 +50,16 @@ int main (int argc, char **argv)
   fclose (outfp);
 
   /* Convert the edge list */ 
-  infp = fopen (argv[1], "r");
+  if ((infp  = fopen (argv[1], "r")) == NULL) {
+    perror("Can't read file at argv[1]");
+    return EXIT_FAILURE;
+  }
   fseek (infp, 0L, SEEK_END);
   sz = ftell (infp);
   rewind (infp);
   /* This is a highly suboptimal way of doing things.
    * If the graph can't fit in RAM, this could be modifed to loop
-   * making sure to read in multiples of  sizeof(struct packed_edge)
+   * making sure to read in multiples of sizeof(struct packed_edge)
    */
   const size_t chunks = 1;
   IJ = xmalloc_large_ext (sz / chunks);
@@ -58,14 +69,19 @@ int main (int argc, char **argv)
     return EXIT_FAILURE;
   }
   fclose (infp);
-  outfp = fopen (argv[3], "w");
+  if ((outfp = fopen (argv[4], "w")) == NULL) {
+    perror("Can't write file at argv[3]");
+    return EXIT_FAILURE;
+  }
   int64_t i,j;
   for (m = 0; m < sz / sizeof(*IJ); m++) {
     i = get_v0_from_edge(&IJ[m]);
     j = get_v1_from_edge(&IJ[m]);
     fprintf (outfp, "%lld %lld\n", i, j);
   }
-  xfree_large (IJ);
 
+  /* Cleanup */
+  fclose (outfp);
+  xfree_large (IJ);
   return EXIT_SUCCESS;
 }

--- a/graph5002el.c
+++ b/graph5002el.c
@@ -6,6 +6,7 @@
  */
 #include <stdio.h>
 #include <stdlib.h>
+#include <unistd.h> // ssize_t
 #include "xalloc.h" // for xmaloc_large_ext
 #include "generator/make_graph.h" // for packed_edge
 #include "options.h" // for NBFS_max
@@ -31,10 +32,11 @@ int main (int argc, char **argv)
   fseek (infp, 0L, SEEK_END);
   sz = ftell (infp);
   rewind (infp);
-  printf ("Found %ld roots\n", sz / 8); // VERBOSE
+  printf ("Found %lld roots\n", (long long) sz / 8); // VERBOSE
   int64_t bfs_root[sz / 8]; // ~64, small enough for the stack
   if ((sz_read = fread (bfs_root, 1, sz, infp)) != sz) {
-    fprintf (stderr, "Expected %ld bytes, read %ld\n", sz, sz_read);
+    fprintf (stderr, "Expected %lld bytes, read %lld\n",
+        (long long) sz, (long long) sz_read);
     return EXIT_FAILURE;
   }
   fclose (infp);
@@ -45,7 +47,7 @@ int main (int argc, char **argv)
   }
   int64_t m;
   for (m = 0; m < sz / 8; m++) {
-    fprintf (outfp, "%lld\n", bfs_root[m]);
+    fprintf (outfp, "%lld\n", (long long) bfs_root[m]);
   }
   fclose (outfp);
 
@@ -65,11 +67,12 @@ int main (int argc, char **argv)
   IJ = xmalloc_large_ext (sz / chunks);
   printf ("Found %ld edges\n", sz / sizeof(*IJ)); // VERBOSE
   if ((sz_read = fread (IJ, 1, sz, infp)) != sz) {
-    fprintf (stderr, "Expected %ld bytes, read %ld\n", sz, sz_read);
+    fprintf (stderr, "Expected %lld bytes, read %lld\n",
+        (long long) sz, (long long) sz_read);
     return EXIT_FAILURE;
   }
   fclose (infp);
-  if ((outfp = fopen (argv[4], "w")) == NULL) {
+  if ((outfp = fopen (argv[3], "w")) == NULL) {
     perror("Can't write file at argv[3]");
     return EXIT_FAILURE;
   }
@@ -77,7 +80,7 @@ int main (int argc, char **argv)
   for (m = 0; m < sz / sizeof(*IJ); m++) {
     i = get_v0_from_edge(&IJ[m]);
     j = get_v1_from_edge(&IJ[m]);
-    fprintf (outfp, "%lld %lld\n", i, j);
+    fprintf (outfp, "%lld %lld\n", (long long) i, (long long) j);
   }
 
   /* Cleanup */

--- a/make-edgelist.c
+++ b/make-edgelist.c
@@ -81,7 +81,10 @@ main (int argc, char **argv)
     return EXIT_FAILURE;
   }
 
-  write (fd, IJ, nedge * sizeof (*IJ));
+  if (write (fd, IJ, nedge * sizeof (*IJ)) < 1) {
+    perror ("Unable to write edge list structure");
+    return EXIT_FAILURE;
+  }
 
   close (fd);
 

--- a/make-edgelist.c
+++ b/make-edgelist.c
@@ -42,6 +42,7 @@ main (int argc, char **argv)
   int * restrict has_adj;
   int fd;
   int64_t desired_nedge;
+  int64_t k, t, nvtx_connected = 0;
   if (sizeof (int64_t) < 8) {
     fprintf (stderr, "No 64-bit support.\n");
     return EXIT_FAILURE;
@@ -81,8 +82,10 @@ main (int argc, char **argv)
     return EXIT_FAILURE;
   }
 
-  write (fd, IJ, nedge * sizeof (*IJ));
-
+  if (write (fd, IJ, nedge * sizeof (*IJ)) < 1) {
+    perror ("Unable to write edge list structure");
+    return EXIT_FAILURE;
+  }
   close (fd);
 
   if (rootname)
@@ -103,17 +106,25 @@ main (int argc, char **argv)
 	  if (i != j)
 	    has_adj[i] = has_adj[j] = 1;
 	}
+      OMP("omp for reduction(+:nvtx_connected)")
+        for (k = 0; k < nvtx_scale; ++k)
+          if (has_adj[k]) ++nvtx_connected;
     }
 
-    /* Sample from {0, ..., nvtx_scale-1} without replacement. */
+    /* Sample from {0, ..., nvtx_scale-1} without replacement, but
+       only from vertices with degree > 0. */
     {
       int m = 0;
-      int64_t t = 0;
-      while (m < NBFS && t < nvtx_scale) {
-	double R = mrg_get_double_orig (prng_state);
-	if (!has_adj[t] || (nvtx_scale - t)*R > NBFS - m) ++t;
-	else bfs_root[m++] = t++;
+      for (k = 0; k < nvtx_scale && m < NBFS; ++k) {
+        unsigned long challenge = (unsigned long)(mrg_get_double_orig(prng_state) * (double)(nvtx_scale-1));
+
+        if (has_adj[challenge]) {
+          size_t i=0;
+          for (; i<m; i++) if (bfs_root[i] == challenge) break; // check for duplicates
+          if (i == m) bfs_root[m++] = challenge; // if not duplicate, add to list
+        }
       }
+
       if (t >= nvtx_scale && m < NBFS) {
 	if (m > 0) {
 	  fprintf (stderr, "Cannot find %d sample roots of non-self degree > 0, using %d.\n",
@@ -127,7 +138,10 @@ main (int argc, char **argv)
     }
 
     xfree_large (has_adj);
-    write (fd, bfs_root, NBFS * sizeof (*bfs_root));
+    if (write (fd, bfs_root, NBFS * sizeof (*bfs_root)) < 1) {
+      perror ("Unable to write bfs roots");
+      return EXIT_FAILURE;
+    }
     close (fd);
   }
 

--- a/make-edgelist.c
+++ b/make-edgelist.c
@@ -42,6 +42,7 @@ main (int argc, char **argv)
   int * restrict has_adj;
   int fd;
   int64_t desired_nedge;
+  int64_t nvtx_connected, k = 0;
   if (sizeof (int64_t) < 8) {
     fprintf (stderr, "No 64-bit support.\n");
     return EXIT_FAILURE;
@@ -77,7 +78,7 @@ main (int argc, char **argv)
 
   if (fd < 0) {
     fprintf (stderr, "Cannot open output file : %s\n",
-	     (dumpname? dumpname : "stdout"));
+             (dumpname? dumpname : "stdout"));
     return EXIT_FAILURE;
   }
 
@@ -97,42 +98,50 @@ main (int argc, char **argv)
     has_adj = xmalloc_large (nvtx_scale * sizeof (*has_adj));
     OMP("omp parallel") {
       OMP("omp for")
-	for (int64_t k = 0; k < nvtx_scale; ++k)
-	  has_adj[k] = 0;
+        for (int64_t k = 0; k < nvtx_scale; ++k)
+          has_adj[k] = 0;
       MTA("mta assert nodep") OMP("omp for")
-	for (int64_t k = 0; k < nedge; ++k) {
-	  const int64_t i = get_v0_from_edge(&IJ[k]);
-	  const int64_t j = get_v1_from_edge(&IJ[k]);
-	  if (i != j)
-	    has_adj[i] = has_adj[j] = 1;
-	}
+        for (int64_t k = 0; k < nedge; ++k) {
+          const int64_t i = get_v0_from_edge(&IJ[k]);
+          const int64_t j = get_v1_from_edge(&IJ[k]);
+          if (i != j)
+            has_adj[i] = has_adj[j] = 1;
+        }
+      OMP("omp for reduction(+:nvtx_connected)")
+        for (k = 0; k < nvtx_scale; ++k)
+          if (has_adj[k]) ++nvtx_connected;
     }
 
-    /* Sample from {0, ..., nvtx_scale-1} without replacement. */
+    /* Sample from {0, ..., nvtx_scale-1} without replacement, but
+       only from vertices with degree > 0. */
     {
       int m = 0;
       int64_t t = 0;
-      while (m < NBFS && t < nvtx_scale) {
-	double R = mrg_get_double_orig (prng_state);
-	if (!has_adj[t] || (nvtx_scale - t)*R > NBFS - m) ++t;
-	else bfs_root[m++] = t++;
+      for (k = 0; k < nvtx_scale && m < NBFS && t < nvtx_connected; ++k) {
+        if (has_adj[k]) {
+        double R = mrg_get_double_orig (prng_state);
+        if ((nvtx_connected - t)*R > NBFS - m) ++t;
+        else bfs_root[m++] = t++;
       }
+    }
       if (t >= nvtx_scale && m < NBFS) {
-	if (m > 0) {
-	  fprintf (stderr, "Cannot find %d sample roots of non-self degree > 0, using %d.\n",
-		   NBFS, m);
-	  NBFS = m;
-	} else {
-	  fprintf (stderr, "Cannot find any sample roots of non-self degree > 0.\n");
-	  exit (EXIT_FAILURE);
-	}
+        if (m > 0) {
+          fprintf (stderr, "Cannot find %d sample roots of non-self degree > 0, using %d.\n",
+                   NBFS, m);
+          NBFS = m;
+        } else {
+          fprintf (stderr, "Cannot find any sample roots of non-self degree > 0.\n");
+          exit (EXIT_FAILURE);
+        }
       }
     }
 
     xfree_large (has_adj);
-    write (fd, bfs_root, NBFS * sizeof (*bfs_root));
+    if (write (fd, bfs_root, NBFS * sizeof (*bfs_root)) < 1) {
+      perror ("Unable to write bfs roots");
+      return EXIT_FAILURE;
+    }
     close (fd);
   }
-
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Now, make-edgelist also does the "challenger" thing that graph500.c
does so there are no roots with degree 0. The make-edgelist function
only writes half the edges (i->j, not j->i) to the file, so the graph500
file reading only reads in half the edges.