### PR TITLE
Fix I/O error: No split collective I/O operation is active

### DIFF
--- a/src/csr_reference.c
+++ b/src/csr_reference.c
@@ -182,4 +182,7 @@ void convert_graph_to_oned_csr(const tuple_graph* const tg, oned_csr_graph* cons
 void free_oned_csr_graph(oned_csr_graph* const g) {
 	if (g->rowstarts != NULL) {free(g->rowstarts); g->rowstarts = NULL;}
 	if (g->column != NULL) {free(g->column); g->column = NULL;}
+#ifdef SSSP
+	if (g->weights != NULL) {free(g->weights); g->weights = NULL;}
+#endif
 }


### PR DESCRIPTION
When running SSSP for large graphs on small process count (for example, SCALE=24 on 2 processes), error occurs and program aborts, because it's trying to end read operation which didn't begin.
Solution: read the next portion of weights, not only edges, when we are doing SSSP.