### PR TITLE
nonconformant arg fix, remove statistics toolbox dependency

### DIFF
--- a/octave/kronecker_generator.m
+++ b/octave/kronecker_generator.m
@@ -35,7 +35,7 @@ function ijw = kronecker_generator (SCALE, edgefactor)
   end
 
   %% Generate weights
-  ijw(3,:) = unifrnd(0, 1, M);
+  ijw(3,:) = rand(1, M);
 
   %% Permute vertex labels
   p = randperm (N);


### PR DESCRIPTION
Fix a bug in kronecker generator - instead of a matrix of MxM on rands, generate 1xM random real numbers uniformly distributed between 0,1. Removes unnecessary dependency on the statistics toolbox - rand(1, M) is equivalent to unifrnd(0,1, [1, M])