### PR TITLE
account changed default (-fno-common) in GCC 10

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,4 +1,4 @@
-CFLAGS = -Drestrict=__restrict__ -O3 -DGRAPH_GENERATOR_MPI -DREUSE_CSR_FOR_VALIDATION -I../aml
+CFLAGS = -Drestrict=__restrict__ -O3 -DGRAPH_GENERATOR_MPI -DREUSE_CSR_FOR_VALIDATION -I../aml -fcommon
 LDFLAGS = -lpthread
 MPICC = mpicc
 


### PR DESCRIPTION
With GCC 10 the default behavior for tentative definitions has changed
(https://gcc.gnu.org/gcc-10/changes.html):

> * GCC now defaults to -fno-common. As a result, global variable
> accesses are more efficient on various targets. In C, global variables
> with multiple tentative definitions now resu lt in linker errors. With
> -fcommon such definitions are silently merged during linking.

This causes builds to fail with versions from that compiler onwards.

Switching to -fcommon resolved that problem. It does not hurt
compilations with older GCC's (tested with 9.3.0) or clang (10.0).