### PR TITLE
bugfix: use parentheses within macros

### DIFF
--- a/src/csr_reference.h
+++ b/src/csr_reference.h
@@ -33,7 +33,7 @@ void free_oned_csr_graph(oned_csr_graph* const g);
 //#define COLUMN(i) column[i]
 //#define SETCOLUMN(a,b) column[a]=b;
 #define BYTES_PER_VERTEX 6
-#define SETCOLUMN(a,b) memcpy(((char*)column)+(BYTES_PER_VERTEX*a),&b,BYTES_PER_VERTEX)
-#define COLUMN(i) (*(int64_t*)(((char*)column)+(BYTES_PER_VERTEX*i)) & (int64_t)(0xffffffffffffffffULL>>(64-8*BYTES_PER_VERTEX)))
+#define SETCOLUMN(a,b) memcpy(((char*)column)+(BYTES_PER_VERTEX*(a)),&b,BYTES_PER_VERTEX)
+#define COLUMN(i) (*(int64_t*)(((char*)column)+(BYTES_PER_VERTEX*(i))) & (int64_t)(0xffffffffffffffffULL>>(64-8*BYTES_PER_VERTEX)))
 
 #endif /* CSR_REFERENCE_H */


### PR DESCRIPTION
Must use parentheses within macros around parameter names, To ensure the safe use of COLUMN(j+1) & SETCOLUMN(j+1, val)