### PR TITLE
bugfix: numa_avail wrong usage

### DIFF
--- a/generator/utils.c
+++ b/generator/utils.c
@@ -50,7 +50,7 @@ xmalloc (size_t sz)
     }
   }
 
-  if (numa_avail)
+  if (numa_avail >= 0)
     out = numa_alloc (sz);
   else
     out = malloc (sz);
@@ -71,7 +71,7 @@ xcalloc (size_t n, size_t sz)
     }
   }
 
-  if (numa_avail) {
+  if (numa_avail >= 0) {
     size_t to_alloc;
     to_alloc = n * sz;
     if (to_alloc < n || to_alloc < sz) {


### PR DESCRIPTION
numa_available() returns -1 when numa unavailable, otherwise >=0. `if(numa_available() >= 0)`  should be used, rather than `if(numa_available())`.